### PR TITLE
Bump utilities to 0.1-4.9f41a2e

### DIFF
--- a/Formula/loginto.rb
+++ b/Formula/loginto.rb
@@ -3,7 +3,7 @@
 class Loginto < Formula
   desc "Utility to help log into remote hosts with convenience"
   homepage "https://github.com/yanghanlin/tdutilities/tree/main/apps/loginto"
-  version "0.1"
+  version "0.1-4.9f41a2e"
 
   # FIXME: `brew style` or `brew audit` seems to report a false positive:
   #        FormulaAudit/LivecheckUrlSymbol: Use url :stable
@@ -20,23 +20,23 @@ class Loginto < Formula
 
   on_macos do
     on_intel do
-      url "https://static.tree-diagram.site/utilities/loginto_0.1_Darwin_x86_64.tar.zst"
-      sha256 "808ac8047a65e970efa9cf673d708a3a9056a579bd3df2dd54bc636967e8f353"
+      url "https://static.tree-diagram.site/utilities/loginto_0.1-4.9f41a2e_Darwin_x86_64.tar.zst"
+      sha256 "ef9f6d0c931910660b6600fc9918886d40bfcbd182bdd6552c06a062c6e67b41"
     end
     on_arm do
-      url "https://static.tree-diagram.site/utilities/loginto_0.1_Darwin_arm64.tar.zst"
-      sha256 "9906d758b187ed932f4b4fdcf9b9e6b9117b553c70a499e0c13f853331b09ddb"
+      url "https://static.tree-diagram.site/utilities/loginto_0.1-4.9f41a2e_Darwin_arm64.tar.zst"
+      sha256 "a851e7765092fcde2409da8a46656991ad1a3554b51ae09e91e43df632191b3b"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://static.tree-diagram.site/utilities/loginto_0.1_Linux_x86_64.tar.zst"
-      sha256 "6059036ff603d50c75de4b2fac1c307468d7b9aee1c24304f7b10ecf12d656dc"
+      url "https://static.tree-diagram.site/utilities/loginto_0.1-4.9f41a2e_Linux_x86_64.tar.zst"
+      sha256 "106280ba0fae8139e78d1598b9b4460d09dbbf43ad93999dc9bcbc259ad77947"
     end
     on_arm do
-      url "https://static.tree-diagram.site/utilities/loginto_0.1_Linux_aarch64.tar.zst"
-      sha256 "89dc41acb030ea0624df5f388b97d721984878c8f1a2f4e3db4e8280a2941bdd"
+      url "https://static.tree-diagram.site/utilities/loginto_0.1-4.9f41a2e_Linux_aarch64.tar.zst"
+      sha256 "1bd804436e168b07ede991f60f2d59fdbc3eda8f1ee340662428df51aa585929"
     end
   end
 


### PR DESCRIPTION
This PR bumps utilities to version 0.1-4.9f41a2e.

<sup>Generated by automated workflow run; view the [logs](https://github.com/yanghanlin/homebrew-hikoboshi/actions/runs/12512947692) for details.</sup>